### PR TITLE
hwui: Remove deprecated compiler flag

### DIFF
--- a/libs/hwui/Android.mk
+++ b/libs/hwui/Android.mk
@@ -149,7 +149,7 @@ endif
 
 ifdef HWUI_COMPILE_FOR_PERF
     # TODO: Non-arm?
-    hwui_cflags += -fno-omit-frame-pointer -marm -mapcs
+    hwui_cflags += -fno-omit-frame-pointer -marm
 endif
 
 # This has to be lazy-resolved because it depends on the LOCAL_MODULE_CLASS


### PR DESCRIPTION
* HWUI_COMPILE_FOR_PERF uses the -mapcs flag
   but it has already been deprecated.
 * Remove the flag "-mapcs" completely

Reference:
https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html#ARM-Options

Change-Id: I6f72b0dc37deefbbfb1c99161f9577a9c447a343
Signed-off-by: Corey Edwards <ensabahnur16@gmail.com>
Signed-off-by: leodiram  <sriramscience7@gmail.com>