### PR TITLE
Fingerprint authentication vibration [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4337,6 +4337,13 @@ public final class Settings {
                 "double_tap_sleep_lockscreen";
 
         /**
+         * whether to enable or disable vibration on succesful fingerprint auth
+         *
+         * @hide
+         */
+        public static final String FINGERPRINT_SUCCESS_VIB = "fingerprint_success_vib";
+
+        /**
          *  Enable statusbar double tap gesture on to put device to sleep
          * @hide
          */

--- a/services/core/java/com/android/server/fingerprint/ClientMonitor.java
+++ b/services/core/java/com/android/server/fingerprint/ClientMonitor.java
@@ -23,8 +23,10 @@ import android.hardware.fingerprint.FingerprintManager;
 import android.hardware.fingerprint.IFingerprintServiceReceiver;
 import android.os.IBinder;
 import android.os.RemoteException;
+import android.os.UserHandle;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
+import android.provider.Settings;
 import android.util.Slog;
 
 import java.util.NoSuchElementException;
@@ -222,7 +224,10 @@ public abstract class ClientMonitor implements IBinder.DeathRecipient {
 
     public final void vibrateSuccess() {
         Vibrator vibrator = mContext.getSystemService(Vibrator.class);
-        if (vibrator != null) {
+
+        boolean FingerprintVib = Settings.System.getIntForUser(mContext.getContentResolver(),
+            Settings.System.FINGERPRINT_SUCCESS_VIB, 1, UserHandle.USER_CURRENT) == 1;
+        if (vibrator != null && FingerprintVib) {
             vibrator.vibrate(mSuccessVibrationEffect);
         }
     }


### PR DESCRIPTION
had a few requests for this, as most devices only vibrate when fingerprint authentication is unsucesful so made it configurable

@xyyx: adapted to 8.1

Signed-off-by: Sipun Ku Mahanta <sipunkumar85@gmail.com>