### PR TITLE
SystemUl: Fix Turkish translation

### DIFF
--- a/packages/SystemUI/res-keyguard/values-tr/strings.xml
+++ b/packages/SystemUI/res-keyguard/values-tr/strings.xml
@@ -29,7 +29,7 @@
     <string name="keyguard_password_enter_password_code" msgid="595980919238127672">"Kilidi açmak için şifreyi yazın"</string>
     <string name="keyguard_password_enter_pin_password_code" msgid="7504123374204446086">"Kilidi açmak için PIN kodunu yazın"</string>
     <string name="keyguard_password_wrong_pin_code" msgid="6535018036285012028">"Yanlış PIN kodu."</string>
-    <string name="keyguard_charged" msgid="2222329688813033109">"Ödeme alındı"</string>
+    <string name="keyguard_charged" msgid="2222329688813033109">"Şarj oldu"</string>
     <string name="keyguard_plugged_in" msgid="89308975354638682">"Şarj oluyor"</string>
     <string name="keyguard_plugged_in_charging_fast" msgid="8869226755413795173">"Hızlı şarj oluyor"</string>
     <string name="keyguard_plugged_in_charging_slowly" msgid="6637043106038550407">"Yavaş şarj oluyor"</string>


### PR DESCRIPTION
When the device is 100% charged, the "Charged" string
on the lock screen is translated into Turkish;
"Ödeme alındı", English equivalent; "Payment received".

So when the device is fully charged, it displays
"Payment received" in English on the screen.

Note: Crowdin not found this string