### PR TITLE
feature: Allow disabling fingerprint wake-and-unlock

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5371,6 +5371,15 @@ public final class Settings {
          * @hide
          */
         public static final String VOLUME_PANEL_ON_LEFT = "volume_panel_on_left";
+        
+        /**
+         * Should we listen for fingerprints when the screen is off?  Devices
+         * with a rear-mounted sensor want this, but certain devices have
+         * the sensor embedded in the power key and listening all the time
+         * causes a poor experience.
+         * @hide
+         */
+        public static final String FP_WAKE_UNLOCK = "fp_wake_unlock";
 
          /**
          * Unlock keystore with fingerprint after reboot
@@ -5573,6 +5582,7 @@ public final class Settings {
             PRIVATE_SETTINGS.add(POCKET_JUDGE);
             PRIVATE_SETTINGS.add(DOUBLE_TAP_SLEEP_GESTURE);
             PRIVATE_SETTINGS.add(DOUBLE_TAP_SLEEP_LOCKSCREEN);
+            PRIVATE_SETTINGS.add(FP_WAKE_UNLOCK);
             PRIVATE_SETTINGS.add(FP_UNLOCK_KEYSTORE);
             PRIVATE_SETTINGS.add(DOT_BUCKET_OVERLAY);
             PRIVATE_SETTINGS.add(AMBIENT_NOTIFICATION_LIGHT);

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -2006,12 +2006,18 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener, Dumpab
 
         // Only listen if this KeyguardUpdateMonitor belongs to the primary user. There is an
         // instance of KeyguardUpdateMonitor for each user but KeyguardUpdateMonitor is user-aware.
-        final boolean shouldListen = (mKeyguardIsVisible || !mDeviceInteractive ||
+        boolean shouldListen = (mKeyguardIsVisible || !mDeviceInteractive ||
                 (mBouncer && !mKeyguardGoingAway) || mGoingToSleep ||
                 shouldListenForFingerprintAssistant() || (mKeyguardOccluded && mIsDreaming))
                 && !mSwitchingUser && !isFingerprintDisabled(getCurrentUser())
                 && (!mKeyguardGoingAway || !mDeviceInteractive) && mIsPrimaryUser
                 && allowedOnBouncer && (mHasFod || !mIsDeviceInPocket);
+
+        if (Settings.System.getInt(mContext.getContentResolver(),
+                   Settings.System.FP_WAKE_UNLOCK, 1) == 0) {
+            shouldListen = shouldListen && !mGoingToSleep && mDeviceInteractive;
+        }
+
         return shouldListen;
     }
 


### PR DESCRIPTION
* When the fingerprint sensor is embedded in the power key, wake-and-unlock is total chaos. Add an option to disable it.
* The default behavior is unchanged.
* source: https://github.com/ArrowOS/android_frameworks_base/commit/9df42e8d12759091d6d164871b64854f2fd9244d